### PR TITLE
Update Makefile for HIPBLAS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -222,24 +222,39 @@ ggml-opencl.o: ggml-opencl.cpp ggml-opencl.h
 endif # LLAMA_CLBLAST
 
 ifdef LLAMA_HIPBLAS
-	ROCM_PATH   ?= /opt/rocm
-	CC          := $(ROCM_PATH)/llvm/bin/clang
-	CXX         := $(ROCM_PATH)/llvm/bin/clang++
+	ROCM_PATH  ?= /opt/rocm
+	CC         := $(ROCM_PATH)/llvm/bin/clang
+	CXX        := $(ROCM_PATH)/llvm/bin/clang++
 	GPU_TARGETS ?= gfx803 gfx900 gfx906 gfx908 gfx90a gfx1030 gfx1100
-	LLAMA_CUDA_DMMV_X ?= 32
-	LLAMA_CUDA_DMMV_Y ?= 1
+	LLAMA_CUDA_DMMV_X ?= 32 
+	LLAMA_CUDA_MMV_Y ?= 1
+	LLAMA_CUDA_KQUANTS_ITER ?= 1
+	LLAMA_CUDA_FORCE_DMMV = true
 	CFLAGS     += -DGGML_USE_HIPBLAS -DGGML_USE_CUBLAS $(shell $(ROCM_PATH)/bin/hipconfig -C)
 	CXXFLAGS   += -DGGML_USE_HIPBLAS -DGGML_USE_CUBLAS $(shell $(ROCM_PATH)/bin/hipconfig -C)
 	LDFLAGS    += -L/opt/rocm/lib -Wl,-rpath=$(ROCM_PATH)/lib -lhipblas -lamdhip64
 	OBJS       += ggml-cuda.o
+ifdef LLAMA_CUDA_DMMV_X
+    CXXFLAGS += -DGGML_CUDA_DMMV_X=$(LLAMA_CUDA_DMMV_X)
+else
+    CXXFLAGS += -DGGML_CUDA_DMMV_X=32
+endif 
+ifeq ($(LLAMA_CUDA_FORCE_DMMV), true)
+    CXXFLAGS += -DGGML_CUDA_FORCE_DMMV # The new MMV Y method can give garbled output for AMD
+endif
+ifdef LLAMA_CUDA_MMV_Y
+    CXXFLAGS += -DGGML_CUDA_MMV_Y=$(LLAMA_CUDA_MMV_Y)
+else ifdef LLAMA_CUDA_DMMV_Y
+    CXXFLAGS += -DGGML_CUDA_MMV_Y=$(LLAMA_CUDA_DMMV_Y) # for backwards compatibility
+else
+    CXXFLAGS += -DGGML_CUDA_MMV_Y=1
+endif
 ifdef LLAMA_CUDA_KQUANTS_ITER
 	CXXFLAGS += -DK_QUANTS_PER_ITERATION=$(LLAMA_CUDA_KQUANTS_ITER)
 else
 	CXXFLAGS += -DK_QUANTS_PER_ITERATION=2
 endif
 ggml-cuda.o: CXXFLAGS += $(addprefix --offload-arch=,$(GPU_TARGETS))
-ggml-cuda.o: CXXFLAGS += -DGGML_CUDA_DMMV_X=$(LLAMA_CUDA_DMMV_X)
-ggml-cuda.o: CXXFLAGS += -DGGML_CUDA_DMMV_Y=$(LLAMA_CUDA_DMMV_Y)
 ggml-cuda.o: ggml-cuda.cu ggml-cuda.h
 	$(CXX) $(CXXFLAGS) -x hip -c -o $@ $<
 endif # LLAMA_HIPBLAS


### PR DESCRIPTION
This update 
* changes the DMMV_Y variable to the newer MMV_Y variable
* exposes some extra options for the user to change such as "LLAMA_CUDA_KQUANTS_ITER" and "LLAMA_CUDA_KQUANTS_ITER"
* sets MMV_Y variable to any DMMV_Y just in case for backwards compatibility
* sets CUDA_FORCE_DMMV to 'true' after observing output and reports of garbled output
* moves the ggml-cuda.o: CXXFLAGS into ifdef statements 


Tested and working on latest build on a 6800xt