### PR TITLE
Fix multi GPU on multiple amd architectures with rocblas_initialize()

### DIFF
--- a/ggml-cuda.cu
+++ b/ggml-cuda.cu
@@ -2535,7 +2535,6 @@ void ggml_init_cublas() {
 #ifdef GGML_USE_HIPBLAS
     rocblas_initialize();
     hipDeviceSynchronize();
-    fprintf(stderr, "hipBLAS INITIALIZED\n");
 #endif
         CUDA_CHECK(cudaGetDeviceCount(&g_device_count));
         GGML_ASSERT(g_device_count <= GGML_CUDA_MAX_DEVICES);

--- a/ggml-cuda.cu
+++ b/ggml-cuda.cu
@@ -10,6 +10,7 @@
 #include <hip/hip_runtime.h>
 #include <hipblas/hipblas.h>
 #include <hip/hip_fp16.h>
+#include "rocblas/rocblas.h"
 #define CUBLAS_COMPUTE_32F HIPBLAS_R_32F
 #define CUBLAS_COMPUTE_32F_FAST_16F HIPBLAS_R_32F
 #define CUBLAS_GEMM_DEFAULT HIPBLAS_GEMM_DEFAULT
@@ -2531,6 +2532,11 @@ void ggml_init_cublas() {
     static bool initialized = false;
 
     if (!initialized) {
+#ifdef GGML_USE_HIPBLAS
+    rocblas_initialize();
+    hipDeviceSynchronize();
+    fprintf(stderr, "hipBLAS INITIALIZED\n");
+#endif
         CUDA_CHECK(cudaGetDeviceCount(&g_device_count));
         GGML_ASSERT(g_device_count <= GGML_CUDA_MAX_DEVICES);
         int64_t total_vram = 0;


### PR DESCRIPTION
fixes the problem experienced while trying to use 2 different AMD gpus at the same time (hangups, crashes, not working)

I was able to get my 6800xt and Vega 64 working together with this small change
      
so far the only issue is it seems to only work with LowVRAM enabled. It's something to do with the scratch buffer. In my own copy, I was able to put all the Repeating layers, Non-repeating layers, v cache, and k cache onto the GPUs (43/43 layers) while keeping Vram scratch buffer disabled and it worked. Not sure how to fix the scratch buffer with multi gpu tho